### PR TITLE
support asobistore, mainly 'shiny radio'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Downloading newest radio programs on the web. Supported radio stations are:
 * niconico
 * freshlive.tv
 * himalaya.fm
+* Abobi Store
 
 If you want to save files as MP3, needs `ffmpeg` command.
 

--- a/bin/rget
+++ b/bin/rget
@@ -40,9 +40,9 @@ class GetWebRadio < Thor
 				else
 					WebRadio(params, opts){|media|media.download}
 				end
-			rescue WebRadio::NotFoundError => e
-				$stderr.puts e.message
-			rescue WebRadio::DownloadError => e
+			rescue WebRadio::NotFoundError,
+				    WebRadio::DownloadError,
+					 WebRadio::UnsupportError => e
 				$stderr.puts e.message
 			end
 		end

--- a/lib/asobistore.rb
+++ b/lib/asobistore.rb
@@ -1,0 +1,55 @@
+require 'open-uri'
+require 'nokogiri'
+require 'mechanize'
+
+class AsobiStore < WebRadio
+	def initialize(params, options)
+		super
+		@offset = 0
+	end
+
+	def download
+		list = Nokogiri(open(@url).read)
+		program = list.css('.list-main-product a.wrap').first.attr('href')
+		content = Nokogiri(open("https://asobistore.jp#{program}").read)
+		player = content.css('iframe').last.attr('src')
+		html = Nokogiri(open("https:#{player}").read)
+		src_m3u8 = html.css('source').first.attr('src')
+		m3u8 = "#{File.dirname(src_m3u8)}/#{open(src_m3u8).read.match(/^[^#].*/)[0]}"
+
+		serial = html.title.scan(/#(\d+)/).flatten.first.to_i
+		@cover = "https:#{html.css('audio').first.attr('poster')}" unless @cover
+		ts_file = "#{@label}##{serial}.ts"
+		mp3_file = "#{@label}##{serial}.mp3"
+
+		begin
+			agent = Mechanize.new
+			agent.get(m3u8)
+			body = agent.page.body
+		rescue ArgumentError
+			body = open(m3u8, &:read)
+		end
+		tses = body.scan(/.*\.ts.*/)
+		key_url = body.scan(/URI="(.*)"/).flatten.first
+
+		if key_url
+			key = agent.get_file(key_url)
+			decoder = OpenSSL::Cipher.new('aes-128-cbc')
+			decoder.key = key
+			decoder.decrypt
+		else
+			decoder = ''
+			def decoder.update(s); return s; end
+		end
+
+		mp3nize(ts_file, mp3_file) do
+			open(ts_file, 'wb:ASCII-8BIT') do |ts|
+				tses.each_with_index do |file, count|
+					print "." if count % 10 == 0
+					ts.write(decoder.update(agent.get_file(file)))
+				end
+				ts.write(decoder.final)
+			end
+		end
+	end
+end

--- a/lib/webradio.rb
+++ b/lib/webradio.rb
@@ -7,6 +7,7 @@ require 'mp3info'
 class WebRadio
 	class NotFoundError < StandardError; end
 	class DownloadError < StandardError; end
+	class UnsupportError < StandardError; end
 
 	def self.instance(params, options)
 		case params['url']
@@ -25,8 +26,11 @@ class WebRadio
 		when %r[^http://m\.himalaya\.fm/]
 			require 'himalaya'
 			Himalaya.new(params, options)
+		when %r[^https://asobistore\.jp/]
+			require 'asobistore'
+			AsobiStore.new(params, options)
 		else
-			raise "unsupported url: #{params['url']}"
+			raise UnsupportError, "unsupported url: #{params['url']}"
 		end
 	end
 

--- a/rget.gemspec
+++ b/rget.gemspec
@@ -4,10 +4,10 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rget"
-  spec.version       = "4.6.1"
+  spec.version       = "4.7.0"
   spec.authors       = ["TADA Tadashi"]
   spec.email         = ["t@tdtds.jp"]
-  spec.description   = %q{Downloading newest radio programs on the web. Supported radio stations are hibiki, onsen, niconico, freshlive and himalaya.}
+  spec.description   = %q{Downloading newest radio programs on the web. Supported radio stations are hibiki, onsen, niconico, freshlive, himalaya and asobi store.}
   spec.summary       = %q{Downloading newest radio programs on the web.}
   spec.homepage      = "https://github.com/wasamas/rget"
   spec.license       = "GPL"

--- a/rget.yaml
+++ b/rget.yaml
@@ -52,3 +52,7 @@ programs:
     desc: ラジオ「たねさんはるさんとはなそ。(意志)」
     url: http://m.himalaya.fm/jp/podcast/190452
     label: たねさんはるさんとはなそ。(意志)
+  shiny_radio:
+    desc: ラジオ「アイドルマスター シャイニーカラーズ はばたきラジオステーション」
+    url: https://asobistore.jp/special/List?ip_seq%5B%5D=1&ip_seq%5B%5D=14&tag_seq%5B%5D=1
+    label: シャニラジ


### PR DESCRIPTION
アソビストアの提供するラジオ番組をサポート。ただし現時点では「シャニラジ」でのみ動作確認している。指定するURLはスペシャルコンテンツの検索結果。サンプルのYAMLを参照のこと。