### PR TITLE
update nicovideo

### DIFF
--- a/lib/nicovideo.rb
+++ b/lib/nicovideo.rb
@@ -34,18 +34,10 @@ class Nicovideo < WebRadio
 		@file = "#{@label}##{'%02d' % serial}#{appendix}.#{video.type}"
 		@mp3_file = @file.sub(/\....$/, '.mp3')
 		mp3nize(@file, @mp3_file) do
-			open(@file, 'wb:ASCII-8BIT') do |o|
-				begin
-					count = 1
-					video.get_video do |body|
-						raise DownloadError.new(body) if body == '403 Forbidden'
-						print '.' if count % 400 == 0
-						o.write(body)
-						count += 1
-					end
-				rescue Niconico::Video::VideoUnavailableError => e
-					raise DownloadError.new(e.message)
-				end
+			loop do
+				print '.'
+				_, _, status = Open3.capture3("youtube-dl -f mp4 -o #{@file} --netrc #{video.url}")
+				break if status == 0
 			end
 		end
 	end

--- a/lib/nicovideo.rb
+++ b/lib/nicovideo.rb
@@ -36,8 +36,9 @@ class Nicovideo < WebRadio
 		mp3nize(@file, @mp3_file) do
 			loop do
 				print '.'
-				_, _, status = Open3.capture3("youtube-dl -f mp4 -o #{@file} --netrc #{video.url}")
+				_, err, status = Open3.capture3("youtube-dl -f mp4 -o #{@file} --netrc #{video.url}")
 				break if status == 0
+				raise DownloadError.new(err) unless err =~ /403: Forbidden/
 			end
 		end
 	end

--- a/rget.gemspec
+++ b/rget.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rget"
-  spec.version       = "4.7.9"
+  spec.version       = "4.8.0"
   spec.authors       = ["TADA Tadashi"]
   spec.email         = ["t@tdtds.jp"]
   spec.description   = %q{Downloading newest radio programs on the web. Supported radio stations are hibiki, onsen, niconico, freshlive, himalaya and asobi store.}


### PR DESCRIPTION
ニコ動のダウンロードを`youtube-dl`を使うように再実装する。`youtube-dl`はニコ動へheartbeatを送らないので途中で失敗するが以下のように回避可能:
  * 失敗は終了ステータス「1」およびstderr内の「403」で判断できる
  * 失敗したときは「指定ファイル名.part」が残る
  * 同コマンド指定で再実行すると継続ダウンロードされる
  * 終了ステータス「0」および指定ファイル名の存在で成功判断

また、認証に関しては`.netrc`が使える。`youtube-dl`のオプションは`--netrc` (引数なし)。`.netrc`のエントリは`niconico`。

なので、実装の方針としては:

* `youtube-dl -f mp4 -o <LABEL>#<SERIAL>.mp4 --netrc <VIDEO-URL>`
* ステータス0以外かつ標準エラー「403: Forbidden」がある限り繰り返し実行
