### PR TITLE
support mp4 media on onsen

### DIFF
--- a/lib/onsen.rb
+++ b/lib/onsen.rb
@@ -32,14 +32,15 @@ private
 		begin
 			serial = html.css("##{program_id}").text.scan(/#(\d+)/).flatten.first
 			mp3_url = html.css('form[target=_self]').select {|form|
-				form.attr('action') =~ %r[/#{program_id}\w+\.mp3]
+				form.attr('action') =~ %r|/#{program_id}\w+\.mp[34]|
 			}.first.attr('action')
 		rescue NoMethodError
 			raise NotFoundError.new("no radio program in #{program_id}.")
 		end
+		src_file = "#{name}##{serial}#{mp3_url.scan(/\.mp[34]$/).first}"
 		mp3_file = "#{name}##{serial}.mp3"
-		mp3nize(mp3_file, mp3_file, false) do
-			open(mp3_file, 'wb:ASCII-8BIT') do |mp3|
+		mp3nize(src_file, mp3_file, false) do
+			open(src_file, 'wb:ASCII-8BIT') do |mp3|
 				mp3.write open(mp3_url, 'rb:ASCII-8BIT', &:read)
 			end
 		end

--- a/rget.gemspec
+++ b/rget.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rget"
-  spec.version       = "4.8.1"
+  spec.version       = "4.8.2"
   spec.authors       = ["TADA Tadashi"]
   spec.email         = ["t@tdtds.jp"]
   spec.description   = %q{Downloading newest radio programs on the web. Supported radio stations are hibiki, onsen, niconico, freshlive, himalaya and asobi store.}


### PR DESCRIPTION
音泉のメディアが`.mp4`の場合があるのでサポートした。`--no-mp3`を指定したとき、`.mp4`が配信されている場合は`.mp4`のままダウンロードされる。そうでない場合は従来どおり。