### PR TITLE
skip forbidden video found by youtube-dl

### DIFF
--- a/rget.gemspec
+++ b/rget.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rget"
-  spec.version       = "4.8.2"
+  spec.version       = "4.8.3"
   spec.authors       = ["TADA Tadashi"]
   spec.email         = ["t@tdtds.jp"]
   spec.description   = %q{Downloading newest radio programs on the web. Supported radio stations are hibiki, onsen, niconico, freshlive, himalaya and asobi store.}


### PR DESCRIPTION
ニコ動で`youtube-dl`コマンド実行中に判明するアクセス不可な動画を検知してリストの次の動画へリトライするように変更。