### PR TITLE
rename 'uliza' to 'hls'

### DIFF
--- a/bin/hls-dl
+++ b/bin/hls-dl
@@ -5,8 +5,8 @@ require 'open-uri'
 require 'thread'
 
 if ARGV.size != 2
-	$stderr.puts "download TS file decoded by Uliza style video streaming"
-	$stderr.puts "ulizadl <playlist.m3u8> <output(.ts)>"
+	$stderr.puts "high speed video downloader of Http Live Streaming (HLS)"
+	$stderr.puts "hls-dl <playlist.m3u8> <output(.ts)>"
 	exit 1
 end
 

--- a/lib/hls.rb
+++ b/lib/hls.rb
@@ -1,8 +1,8 @@
 require 'webradio'
 
-class Uliza < WebRadio
+class HLS < WebRadio
 private
-	def uliza_download(name, html, serial_pattern, m3u_pattern)
+	def hls_download(name, html, serial_pattern, m3u_pattern)
 		serial = html.scan(serial_pattern).flatten.sort{|a,b| a.to_i <=> b.to_i}.last
 		@m4a_file = "#{name}##{serial}.m4a"
 		@mp3_file = @m4a_file.sub(/\.m4a$/, '.mp3')


### PR DESCRIPTION
仮にulizaという名前を与えていたHLS形式のストリーミングを、ちゃんとhlsというネームスペースに変更した。