### PR TITLE
Update_onsen_202112

### DIFF
--- a/lib/hls.rb
+++ b/lib/hls.rb
@@ -3,13 +3,14 @@ require 'open3'
 
 class HLS < WebRadio
 private
-	def hls_download(name, serial, m3u_meta)
+	def hls_download(name, serial, m3u_meta, headers = {})
 		mp4_file = "#{name}##{serial}.mp4"
 		mp3_file = "#{name}##{serial}.mp3"
-		m3u = URI.open(m3u_meta, &:read).scan(/^[^#].*/).first
+		m3u = URI.open(m3u_meta, headers, &:read).scan(/^[^#].*/).first
 		m3u = Pathname(m3u_meta).dirname.join(m3u) if Pathname(m3u).relative?
+		ffmpeg_headers = headers.empty? ? '' : "-headers '" + headers.map{|k, v| "#{k}: #{v}"}.join("\r\n") + "'"
 		mp3nize(mp4_file, mp3_file) do
-			result = Open3.capture3(%Q[ffmpeg -loglevel error -protocol_whitelist file,http,https,tcp,tls,crypto -i "#{m3u}" "#{mp4_file}"])
+			result = Open3.capture3(%Q[ffmpeg -loglevel error -protocol_whitelist file,http,https,tcp,tls,crypto #{ffmpeg_headers} -i "#{m3u}" "#{mp4_file}"])
 			unless result[2].to_i == 0
 				raise WebRadio::DownloadError.new("failed download the radio program (#{@label}).")
 			end

--- a/lib/onsen.rb
+++ b/lib/onsen.rb
@@ -5,21 +5,25 @@ require 'nokogiri'
 require 'json'
 
 class Onsen < HLS
+	HEADERS = {
+		"Referer" => 'https://www.onsen.ag/'
+	}
+
 	def initialize(params, options)
 		super
 		@cover = "//*[@class='newest-content--left']//img[1]/@src" unless @cover
 	end
 
 	def download
-		html = URI.open(@url, &:read)
+		html = URI.open(@url, HEADERS, &:read)
 		serial = Nokogiri(html).css('.play-video-info td')[0].text.scan(/\d+/)[0].to_i
 		m3u8 = JSON.parse(html.scan(%r|streaming_url:("https:.*?.m3u8")|).flatten.sort.last)
-		hls_download(@label, serial, m3u8)
+		hls_download(@label, serial, m3u8, HEADERS)
 	end
 
 	def dump
 		tag = Pathname(@url).basename.to_s.gsub(%r|[-/]|, '_')
-		html = Nokogiri(URI.open(@url, &:read))
+		html = Nokogiri(URI.open(@url, HEADERS, &:read))
 		title = html.css('h3')[0].text
 		return {
 			tag => {

--- a/rget.gemspec
+++ b/rget.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rget"
-  spec.version       = "4.12.0"
+  spec.version       = "4.13.0"
   spec.authors       = ["Tada, Tadashi"]
   spec.email         = ["t@tdtds.jp"]
   spec.description   = %q{Downloading newest radio programs on the web. Supported radio stations are hibiki, onsen, niconico, himalaya, asobi store, stand.fm and youtube.}

--- a/rget.yaml
+++ b/rget.yaml
@@ -9,7 +9,6 @@ programs:
     desc: ラジオ「松井恵理子のにじらじっ！」
     url: http://www.onsen.ag/program/matsui/
     label: 松井恵理子のにじらじ
-    cover: //*[@id='newProgramWrap']//img[1]/@src
   suzakinishi:
     desc: 洲崎西
     url: http://ch.nicovideo.jp/search/%E6%B4%B2%E5%B4%8E%E8%A5%BF?channel_id=ch2589908&mode=s&sort=f&order=d&type=video


### PR DESCRIPTION
音泉がRefererを要求するようになったので対応。HLSでカスタムヘッダを受け付けるようにして、汎用的にした。