### PR TITLE
fix for update of onsen

### DIFF
--- a/rget.gemspec
+++ b/rget.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "rget"
-  spec.version       = "4.13.2"
+  spec.version       = "4.14.0"
   spec.authors       = ["Tada, Tadashi"]
   spec.email         = ["t@tdtds.jp"]
   spec.description   = %q{Downloading newest radio programs on the web. Supported radio stations are hibiki, onsen, niconico, himalaya, asobi store, stand.fm and youtube.}


### PR DESCRIPTION
音泉のフォーマット変更で正しい m3u8 を取得できなかったのを修正。
なお、一覧に特番が入っている場合はスキップし、連番が入っているものをダウンロードする。